### PR TITLE
Notify

### DIFF
--- a/discordNotifier.js
+++ b/discordNotifier.js
@@ -35,7 +35,7 @@ function sendToWebhooks(validator, fields, color){
                     description += `<@${discordId}> `
                 }
             }
-            embed.setDescription(description)
+            embed.setText(description)
             embed.setFooter(footer)
             const hook = new Webhook(webhookUrl)
             hook.setUsername(WEBHOOK_NAME)


### PR DESCRIPTION
With the discord id tags inside the description, a discord notification is not fired. Using the text, outside of the embed, it will notify.